### PR TITLE
Added Trusted email validation functionality in Signup form

### DIFF
--- a/index.php
+++ b/index.php
@@ -270,8 +270,8 @@ if (isset($_SESSION['loggedin']) && $_SESSION['loggedin'] == true) {
         <div class="block">
           <h2 class="font-semibold text-gray-800 text-lg">Get in touch</h2>
           <div class="flex flex-col gap-2 text-[#6A6E5C] mt-2">
-            <a href="#">hello@tiffy.com</a>
-            <a href="#">+91 9820223338</a>
+            <a href="mailto:hello@tiffy.com">hello@tiffy.com</a>
+            <a href="callto:+919820223338">+91 9820223338</a>
           </div>
         </div>
         <div class="block">

--- a/user_signup.php
+++ b/user_signup.php
@@ -148,14 +148,15 @@ if($_SERVER["REQUEST_METHOD"]=="POST"){
         <div class="w-96 ml-auto flex flex-col gap-8">
           <h1 class="text-3xl font-bold">Hello, Good to see you</h1>
 
-          <form action="user_signup.php" method="post" class="flex flex-col gap-4">
+          <form action="user_signup.php" method="post" onsubmit="return validateEmail()" class="flex flex-col gap-4">
             <div class="form-group">
               <label for="name" class="mb-2">Name</label>
               <input type="text" id="name" name="name" placeholder="Enter your name" class="p-2 border border-black" required>
             </div>
             <div class="form-group">
               <label for="email" class="mb-2">Email</label>
-              <input type="email" id="email-id" name="email" placeholder="example@example.com" class="p-2 border border-black" required>
+              <input type="email" id="email-id" name="email" placeholder="example@example.com" class="p-2 border border-black" required><br>
+              <span id="email-error" class="text-red-500 text-sm hidden">Please enter a trusted email address.</span>
             </div>
             <div class="form-group">
               <label for="password" class="mb-2">Password</label>
@@ -185,6 +186,47 @@ if($_SERVER["REQUEST_METHOD"]=="POST"){
 </body>
 
     <script>
+      function validateEmail() {
+        const trustedDomains = [
+        'gmail.com',
+        'outlook.com',
+        'yahoo.com',
+        'protonmail.com',
+        'icloud.com',
+        'tutanota.com',
+        'hotmail.com',
+        'live.com',
+        'mail.com',
+        'zoho.com',
+        'gmx.com',
+        'aol.com',
+        'fastmail.com',
+        'yandex.com',
+        '*.edu',
+        '*.ac.uk',
+        '*.edu.in',
+        '*.edu.au',
+        'examplecompany.com',
+        'mailfence.com',
+        'posteo.de',
+        'runbox.com',
+        'countermail.com',
+        'hushmail.com',
+        'inbox.com',
+        'mail.ru',
+        'rediffmail.com',
+        'seznam.cz'
+      ];
+          
+      const email = document.getElementById("email-id").value;
+          
+      if (!trustedDomains.includes(email)) {
+        document.getElementById("email-error").classList.remove("hidden");
+        return false;
+      }
+
+      return true;
+      }
       const eyeBtnPassword =document.getElementById("eye-btn-p");
       const eyeBtnConfirmPassword =document.getElementById("eye-btn-cp");
       const passwordField =document.getElementById("password");


### PR DESCRIPTION
### PR Description: Implemented Email Domain Validation in Signup Form  

Fixes #250 

1. Added validation to allow only trusted email domains: `gmail.com`, `outlook.com`, `yahoo.com`, `protonmail.com`, `icloud.com`, `tutanota.com`, and more.  
2. Displays an alert message if the email is from an untrusted domain and blocks submission.  
3. Ensures data integrity by filtering spam and temporary emails. 

@Vimall03  
Pls add level, gssoc-extd.