### PR TITLE
added backend schema, server actions and testing API for faq forum

### DIFF
--- a/alimento-nextjs/actions/forum/Answer.tsx
+++ b/alimento-nextjs/actions/forum/Answer.tsx
@@ -1,0 +1,79 @@
+"use server"
+
+import prismadb from "@/lib/prismadb";
+import { Answer } from "@prisma/client";
+import { UUID } from "crypto";
+
+type CreateAnswerResponse = {
+  success: boolean;
+  data?: Answer
+  error?: string;
+};
+
+export async function createAnswer(
+  questionId: string,
+  content: string
+): Promise<CreateAnswerResponse> {
+  try {
+
+    const newAnswer = await prismadb.answer.create({
+      data: {
+        content,
+        questionId,
+      },
+    });
+
+    await prismadb.question.update({
+      where: { id: questionId },
+      data: { answered: true },
+    });
+
+    return {
+      success: true,
+      data: newAnswer
+    };
+  } catch (error) {
+    console.error("Error creating answer:", error);
+    return {
+      success: false,
+      error: "Failed to create answer",
+    };
+  }
+}
+
+
+
+
+type DeleteAnswerResponse = {
+  success: boolean;
+  data?: Answer;
+  error?: string;
+};
+
+export async function deleteSpecificAnswer(answerId: string): Promise<DeleteAnswerResponse> {
+  try {
+    const deletedAnswer = await prismadb.answer.delete({
+      where: {
+        id: answerId,
+      },
+    });
+
+    if (!deletedAnswer) {
+      return {
+        success: false,
+        error: "Error in deleting the answer",
+      };
+    }
+
+    return {
+      success: true,
+      data: deletedAnswer,
+    };
+  } catch (error) {
+    console.error("Error deleting specific answer:", error);
+    return {
+      success: false,
+      error: "Failed to delete specific answer",
+    };
+  }
+}

--- a/alimento-nextjs/actions/forum/Question.tsx
+++ b/alimento-nextjs/actions/forum/Question.tsx
@@ -1,0 +1,141 @@
+'use server';
+
+import prismadb from '@/lib/prismadb';
+import { Answer, Question } from '@prisma/client';
+import { UUID } from 'crypto';
+
+interface QuestionWithAnswer extends Question{
+  answers?:Answer[]
+}
+
+type QuestionResponse = {
+  success: boolean;
+  data?: Question;
+  error?: string;
+};
+
+type getQuestionsResponse = {
+  success: boolean;
+  data?: QuestionWithAnswer[];
+  error?: string;
+};
+
+
+export async function createQuestion(
+  content: string
+): Promise<QuestionResponse> {
+  try {
+    const newQuestion = await prismadb.question.create({
+      data: {
+        content,
+      },
+    });
+
+    return {
+      success: true,
+      data: newQuestion,
+    };
+  } catch (error) {
+    console.error('Error creating question:', error);
+    return {
+      success: false,
+      error: 'Failed to create question',
+    };
+  }
+}
+
+export async function getUnansweredQuestions(
+): Promise<getQuestionsResponse> {
+  try {
+    const unAnsweredQuestions = await prismadb.question.findMany({
+      where: {
+        answered: false,
+      },
+    });
+
+    if (!unAnsweredQuestions.length) {
+      return {
+        success: false,
+        error: 'No unanswered questions!',
+      };
+    }
+
+    return {
+      success: true,
+      data: unAnsweredQuestions,
+    };
+  } catch (error) {
+    console.error('Error fetching unanswered questions', error);
+    return {
+      success: false,
+      error: 'Failed to fetch unanswered questions',
+    };
+  }
+}
+
+
+export async function getAnsweredQuestions(
+): Promise<getQuestionsResponse> {
+  try {
+    const AnsweredQuestions = await prismadb.question.findMany({
+      where: {
+        answered: true,
+      },
+      include:{
+        answers:true
+      }
+    });
+
+    if (!AnsweredQuestions.length) {
+      return {
+        success: false,
+        error: 'No unanswered questions!',
+      };
+    }
+
+    return {
+      success: true,
+      data: AnsweredQuestions,
+    };
+  } catch (error) {
+    console.error('Error fetching answered questions', error);
+    return {
+      success: false,
+      error: 'Failed to fetch answered questions',
+    };
+  }
+}
+
+//  This will be only accessible by the admin
+
+// deletes a question and all its related answers if present
+
+export async function deleteQuestion(
+  questionId: string,
+): Promise<QuestionResponse> {
+  try {
+    const deletedQuestion = await prismadb.question.delete({
+      where: {
+        id:questionId
+      },
+    });
+
+    if (!deletedQuestion) {
+      return {
+        success: false,
+        error: 'error in deleting the question',
+      };
+    }
+
+    return {
+      success: true,
+      data: deletedQuestion,
+    };
+  } catch (error) {
+    console.error('Error deleting specific question', error);
+    return {
+      success: false,
+      error: 'Failed to delete specific question',
+    };
+  }
+}

--- a/alimento-nextjs/app/api/testing/faq/[customerId]/[questionId]/route.ts
+++ b/alimento-nextjs/app/api/testing/faq/[customerId]/[questionId]/route.ts
@@ -1,0 +1,39 @@
+
+import { createAnswer } from "@/actions/forum/Answer";
+import { createQuestion, getUnansweredQuestions } from "@/actions/forum/Question";
+import { NextRequest, NextResponse } from "next/server";
+
+export type Params = Promise<{
+  customerId: string;
+  questionId : string
+}>;
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Params }
+) {
+  const { customerId , questionId } = await params;
+
+  if (!customerId) {
+    return new NextResponse('customer not authenticated', { status: 401 });
+  }
+
+  const { content } = await request.json();
+
+  if (!content || !questionId) {
+    return new NextResponse('Content and questionId is required', { status: 400 });
+  }
+
+  try {
+    const resp = await createAnswer(questionId,content);
+
+    if (resp.success) {
+      return NextResponse.json(resp.data);
+    } else {
+      return NextResponse.json({ err: resp.error }, { status: 400 });
+    }
+  } catch (err) {
+    console.log('[CREATE_ANSWER]', err);
+    return new NextResponse('Internal Server Error', { status: 500 });
+  }
+}

--- a/alimento-nextjs/app/api/testing/faq/[customerId]/route.ts
+++ b/alimento-nextjs/app/api/testing/faq/[customerId]/route.ts
@@ -1,0 +1,37 @@
+
+import { createQuestion, getUnansweredQuestions } from "@/actions/forum/Question";
+import { NextRequest, NextResponse } from "next/server";
+
+export type Params = Promise<{
+  customerId: string;
+}>;
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Params }
+) {
+  const { customerId } = await params;
+
+  if (!customerId) {
+    return new NextResponse('customer not authenticated', { status: 401 });
+  }
+
+  const { content } = await request.json();
+
+  if (!content) {
+    return new NextResponse('Content is required', { status: 400 });
+  }
+
+  try {
+    const resp = await createQuestion(content);
+
+    if (resp.success) {
+      return NextResponse.json(resp.data);
+    } else {
+      return NextResponse.json({ err: resp.error }, { status: 400 });
+    }
+  } catch (err) {
+    console.log('[CREATE_QUESTION]', err);
+    return new NextResponse('Internal Server Error', { status: 500 });
+  }
+}

--- a/alimento-nextjs/app/api/testing/faq/admin/[adminId]/answer/[answerId]/route.ts
+++ b/alimento-nextjs/app/api/testing/faq/admin/[adminId]/answer/[answerId]/route.ts
@@ -1,0 +1,36 @@
+
+import { deleteSpecificAnswer } from "@/actions/forum/Answer";
+import { NextRequest, NextResponse } from "next/server";
+
+export type Params = Promise<{
+  userId: string;
+  answerId: string;
+}>;
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Params }
+) {
+  const { userId, answerId } = await params;
+
+  if (!userId) {
+    return new NextResponse('User not authenticated', { status: 401 });
+  }
+
+  if (!answerId) {
+    return new NextResponse('Answer ID is required', { status: 400 });
+  }
+
+  try {
+    const resp = await deleteSpecificAnswer(answerId);
+
+    if (resp.success) {
+      return NextResponse.json(resp.data);
+    } else {
+      return NextResponse.json({ err: resp.error }, { status: 400 });
+    }
+  } catch (err) {
+    console.log('[DELETE_ANSWER]', err);
+    return new NextResponse('Internal Server Error', { status: 500 });
+  }
+}

--- a/alimento-nextjs/app/api/testing/faq/admin/[adminId]/question/[questionId]/route.ts
+++ b/alimento-nextjs/app/api/testing/faq/admin/[adminId]/question/[questionId]/route.ts
@@ -1,0 +1,36 @@
+
+import { deleteQuestion } from "@/actions/forum/Question";
+import { NextRequest, NextResponse } from "next/server";
+
+export type Params = Promise<{
+  adminId: string;
+  questionId: string;
+}>;
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Params }
+) {
+  const { adminId, questionId } = await params;
+
+  if (!adminId) {
+    return new NextResponse('Admin not authenticated', { status: 401 });
+  }
+
+  if (!questionId) {
+    return new NextResponse('Question ID is required', { status: 400 });
+  }
+
+  try {
+    const resp = await deleteQuestion(questionId);
+
+    if (resp.success) {
+      return NextResponse.json(resp.data);
+    } else {
+      return NextResponse.json({ err: resp.error }, { status: 400 });
+    }
+  } catch (err) {
+    console.log('[DELETE_QUESTION]', err);
+    return new NextResponse('Internal Server Error', { status: 500 });
+  }
+}

--- a/alimento-nextjs/app/api/testing/faq/route.ts
+++ b/alimento-nextjs/app/api/testing/faq/route.ts
@@ -1,0 +1,31 @@
+
+import { getAnsweredQuestions, getUnansweredQuestions } from "@/actions/forum/Question";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(request: NextRequest) {
+  try {
+    // Extract the query parameter
+    const url = new URL(request.url);
+    const questionStatus = url.searchParams.get("question");
+
+    // Check if the query parameter is 'answered' or 'unanswered'
+    let resp;
+
+    if (questionStatus === "answered") {
+      resp = await getAnsweredQuestions();
+    } else if (questionStatus === "unanswered") {
+      resp = await getUnansweredQuestions();
+    } else {
+      return new NextResponse("Invalid query parameter. Use '?question=answered' or '?question=unanswered'.", { status: 400 });
+    }
+
+    if (resp.success) {
+      return NextResponse.json(resp.data);
+    } else {
+      return NextResponse.json({ err: resp.error }, { status: 400 });
+    }
+  } catch (err) {
+    console.log('[GET_QUESTIONS]', err);
+    return new NextResponse('Internal Server Error', { status: 500 });
+  }
+}

--- a/alimento-nextjs/prisma/schema.prisma
+++ b/alimento-nextjs/prisma/schema.prisma
@@ -79,3 +79,22 @@ model Image {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
+
+
+model Question {
+  id        String   @id @default(cuid()) @map("_id")
+  content   String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  answers   Answer[] @relation("QuestionAnswers") // Removed onDelete: Cascade from here
+  answered  Boolean  @default(false)
+}
+
+model Answer {
+  id         String   @id @default(cuid()) @map("_id")
+  content    String
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+  questionId String
+  question   Question @relation("QuestionAnswers", fields: [questionId], references: [id], onDelete: Cascade) // Moved onDelete: Cascade to this side
+}


### PR DESCRIPTION
# Feature: Q&A Forum Backend Integration

## Overview

This PR introduces the backend functionality for a Question and Answer (Q&A) forum on the website. The following features have been implemented:

- **Schema Definition**: The schema for `Question` and `Answer` has been added to the database.
- **Backend Actions**:
  - `createQuestion`: A backend action that allows authenticated users to create questions.
  - `createAnswer`: A backend action that allows authenticated users to answer questions.
  - `getAnsweredQuestions`: A backend action to fetch all answered questions, available to all users.
  - `getUnansweredQuestions`: A backend action to fetch all unanswered questions, available to all users.
  - `deleteQuestion`: A backend action to delete a specific question along with its related answers. This is an admin-only action.

- **API Endpoints**:
  - The endpoints for testing all routes (except the admin-protected delete route) have been created. Since the admin feature is not yet implemented, the delete question action is not available in the current API testing but has been set up for future use.


PR1 #258 



https://github.com/user-attachments/assets/c56c4cee-bfe0-42e2-86ac-eb361b1e6448


